### PR TITLE
Support for non-standard request parameters

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -91,8 +91,7 @@ class OAuthResponse(object):
 
 class OAuthClient(oauth2.Client):
 
-    def request_new_token(self, uri, callback=None):
-        params = {}
+    def request_new_token(self, uri, callback=None, params={}):
         if callback is not None:
             params['oauth_callback'] = callback
         req = oauth2.Request.from_consumer_and_token(
@@ -149,7 +148,7 @@ class OAuthRemoteApp(object):
     def __init__(self, oauth, name, base_url,
                  request_token_url,
                  access_token_url, authorize_url,
-                 consumer_key, consumer_secret):
+                 consumer_key, consumer_secret, request_token_params={}):
         self.oauth = oauth
         #: the `base_url` all URLs are joined with.
         self.base_url = base_url
@@ -160,7 +159,7 @@ class OAuthRemoteApp(object):
         self.consumer_key = consumer_key
         self.consumer_secret = consumer_secret
         self.tokengetter_func = None
-
+        self.request_token_params = request_token_params
         self._consumer = oauth2.Consumer(self.consumer_key,
                                          self.consumer_secret)
         self._client = OAuthClient(self._consumer)
@@ -244,7 +243,8 @@ class OAuthRemoteApp(object):
         if callback is not None:
             callback = urljoin(request.url, callback)
         resp, content = self._client.request_new_token(
-            self.expand_url(self.request_token_url), callback)
+            self.expand_url(self.request_token_url), callback,
+                self.request_token_params)
         if resp['status'] != '200':
             raise OAuthException('Failed to generate request token')
         data = parse_response(resp, content)


### PR DESCRIPTION
Google requires a single non-standard OAuth parameter called 'scope' http://code.google.com/apis/accounts/docs/OAuth_ref.html This parameter is non-optional and is passed when fetching the request token.

I added an optional dictionary parameter to the remote_app method that allows you to pass any number of additional values.

It may be cleaner to allow you to set these parameters after the client is created instead of cluttering up the init method, but this works.  I'm happy to refractor it to any suggestions you may have.
