### PR TITLE
Fix: TypeError: must be string or buffer, not None (TypeError against python-oauth2)

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -199,7 +199,7 @@ class OAuthRemoteApp(object):
         """
         return oauth2.Client(self._consumer, self.get_request_token())
 
-    def request(self, url, data=None, headers=None, format='urlencoded',
+    def request(self, url, data="", headers=None, format='urlencoded',
                 method='GET', content_type=None):
         """Sends a request to the remote server with OAuth tokens attached.
         The `url` is joined with :attr:`base_url` if the URL is relative.
@@ -225,9 +225,9 @@ class OAuthRemoteApp(object):
         url = self.expand_url(url)
         if method == 'GET':
             assert format == 'urlencoded'
-            if data is not None:
+            if not data:
                 url = add_query(url, data)
-                data = None
+                data = ""
         else:
             if content_type is None:
                 data, content_type = encode_request_data(data, format)


### PR DESCRIPTION
This change set fixes a type mismatch for empty GET request bodies.

The error occurs with python's oauth2 version 1.5.170 (eg. latest version shipped with PyPI) and breaks at least 
twitter's (example bundled with flask-oauth) and meetup's oauth api.
