### PR TITLE
It would be nice to allow for extra params to be provided during authoriz

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -292,7 +292,7 @@ class OAuthRemoteApp(object):
         session.pop(self.name + '_oauthtok', None)
         session.pop(self.name + '_oauthredir', None)
 
-    def authorize(self, callback=None):
+    def authorize(self, callback=None, extra_params=None):
         """Returns a redirect response to the remote authorization URL with
         the signed callback given.  The callback must be `None` in which
         case the application will most likely switch to PIN based authentication
@@ -308,7 +308,8 @@ class OAuthRemoteApp(object):
             # This is for things like facebook's oauth.  Since we need the
             # callback for the access_token_url we need to keep it in the
             # session.
-            params = dict(self.request_token_params)
+            params = extra_params or {}
+            params.update(dict(self.request_token_params))
             params['redirect_uri'] = callback
             params['client_id'] = self.consumer_key
             session[self.name + '_oauthredir'] = callback


### PR DESCRIPTION
It would be nice to allow for extra params to be provided during authorize phase. This way, if a user is trying to sign in to the local application its possible to provide dynamic parameters with the callback. For example, a 'next' request argument to redirect the user to an appropriate page after sign in. Perhaps this isn't exactly the best or right way to do it, but I wanted to suggest it.
