### PR TITLE
set is_form_encoded to be True when get request token using POST method

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -96,7 +96,8 @@ class OAuthClient(oauth2.Client):
             params['oauth_callback'] = callback
         req = oauth2.Request.from_consumer_and_token(
             self.consumer, token=self.token,
-            http_method='POST', http_url=uri, parameters=params)
+            http_method='POST', http_url=uri, parameters=params,
+            is_form_encoded=True)
         req.sign_request(self.method, self.consumer, self.token)
         body = req.to_postdata()
         headers = {


### PR DESCRIPTION
set is_form_encoded to avoid adding extra oauth_body_hash which must not be included on requests with form-encoded request bodies
