### PR TITLE
The request to get the access_token to have the args in the body if required to use the POST method

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -351,7 +351,10 @@ class OAuthRemoteApp(object):
             'redirect_uri':     session.get(self.name + '_oauthredir')
         }
         url = add_query(self.expand_url(self.access_token_url), remote_args)
-        resp, content = self._client.request(url, self.access_token_method)
+        body = ''
+        if self.access_token_method == "POST":
+            body = url_encode(remote_args)
+        resp, content = self._client.request(url, self.access_token_method, body=body)
         data = parse_response(resp, content)
         if resp['status'] != '200':
             raise OAuthException('Invalid response from ' + self.name, data)


### PR DESCRIPTION
Instagram's API requires you to send the parameters in the body of the request when requesting the access_token in exchange of the code: http://instagr.am/developer/authentication/

The flask-oauth library needs to be updated to send the content of the remote_args in the body of the oauth2 request.
