### PR TITLE
add error handling for 401 response from google

### DIFF
--- a/example/google.py
+++ b/example/google.py
@@ -42,8 +42,10 @@ def index():
                   None, headers)
     try:
         res = urlopen(req)
-    except URLError:
-        return res.read()
+    except URLError as e:
+      if e.code == 401:  # Unauthorized - bad token
+        session.pop('access_token',None)
+        return redirect(url_for('login'))
 
     return res.read()
 


### PR DESCRIPTION
There's a subtle bug on line 46:
https://github.com/mitsuhiko/flask-oauth/blob/master/example/google.py#L46

If you've entered that `except` block, `res` hasn't been assigned yet.

I was able to fix a bug in a project that I modeled after `google.py` by handling the 401 this way.  I wasn't able to recreate the bug in this example, though.
