### PR TITLE
Fix a bug where supplying a data argument to a GET request would raise a...

### DIFF
--- a/flaskext/oauth.py
+++ b/flaskext/oauth.py
@@ -254,7 +254,7 @@ class OAuthRemoteApp(object):
         url = self.expand_url(url)
         if method == 'GET':
             assert format == 'urlencoded'
-            if not data:
+            if data:
                 url = add_query(url, data)
                 data = ""
         else:


### PR DESCRIPTION
...n exception if data was not a string

In a GET request data must be part of the query string.
