### PR TITLE
Authorization URL customization

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -320,12 +320,14 @@ class OAuthRemoteApp(object):
         session.pop(self.name + '_oauthtok', None)
         session.pop(self.name + '_oauthredir', None)
 
-    def authorize(self, callback=None):
+    def authorize(self, callback=None, extra_params=None):
         """Returns a redirect response to the remote authorization URL with
         the signed callback given.  The callback must be `None` in which
         case the application will most likely switch to PIN based authentication
         or use a remotely stored callback URL.  Alternatively it's an URL
         on the system that has to be decorated as :meth:`authorized_handler`.
+        You can also pass any `extra_params` that will be added to the
+        authorization URL.
         """
         if self.request_token_url:
             token = self.generate_request_token(callback)[0]
@@ -340,6 +342,8 @@ class OAuthRemoteApp(object):
             params['redirect_uri'] = callback
             params['client_id'] = self.consumer_key
             params['response_type'] = 'code'
+            if extra_params:
+                params.update(extra_params)
             session[self.name + '_oauthredir'] = callback
             url = add_query(self.expand_url(self.authorize_url), params)
 


### PR DESCRIPTION
This enables library users to pass extra parameters (as extra_params) that will be added to redirected URL to OAuthRemoteApp's authorize method.

This is usefull for facebook if you want to show non-default page layout - like the display parameter (see https://developers.facebook.com/docs/reference/dialogs/)

I've seen the https://github.com/mitsuhiko/flask-oauth/pull/15 request but I don't think putting extra params into callback_url is a good solution, this is much cleaner IMHO.
