### PR TITLE
Add ability to include additional CA certs for SSL requests

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -379,12 +379,10 @@ class OAuthRemoteApp(object):
         function.
         """
         client = self.make_client()
-        remote_args = {
-            'oauth_verifier': request.args['oauth_verifier']
-        }
-        remote_args.update(self.access_token_params)
-        url = add_query(self.expand_url(self.access_token_url), remote_args)
-        resp, content = client.request(url, self.access_token_method)
+        resp, content = client.request('%s?oauth_verifier=%s' % (
+            self.expand_url(self.access_token_url),
+            request.args['oauth_verifier']
+        ), self.access_token_method)
         data = parse_response(resp, content)
         if not self.status_okay(resp):
             raise OAuthException('Invalid response from ' + self.name,


### PR DESCRIPTION
In working with an OAuth endpoint that used SSL, I discovered that the certifying authority’s certificate (Network Solutions in this case) was not included in the cacerts.txt file that ships with httplib2. This is a simple patch which adds a configuration parameter to the initial setup that allows passing in a path to a `pem` file that contains additional certificates.
