### PR TITLE
Support access_token_params for OAuth 1 requests

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -178,8 +178,7 @@ class OAuthRemoteApp(object):
                  consumer_key, consumer_secret,
                  request_token_params=None,
                  access_token_params=None,
-                 access_token_method='GET',
-                 additional_certs=None):
+                 access_token_method='GET'):
         self.oauth = oauth
         #: the `base_url` all URLs are joined with.
         self.base_url = base_url
@@ -196,8 +195,6 @@ class OAuthRemoteApp(object):
         self._consumer = oauth2.Consumer(self.consumer_key,
                                          self.consumer_secret)
         self._client = OAuthClient(self._consumer)
-        if additional_certs:
-            self._client.ca_certs = additional_certs
 
     def status_okay(self, resp):
         """Given request data, checks if the status is okay."""


### PR DESCRIPTION
In working with an OAuth 1 endpoint that requires a scope parameter to be passed in when getting the access token, I discovered that, while this library supported passing that access_token_params for an OAuth 2 request, when it came to handling the OAuth 1 requests, those parameters were ignored. This is an attempt to fix that.
