### PR TITLE
Fixed: Decoding XML breaks ElementTree

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -40,12 +40,7 @@ def parse_response(resp, content, strict=False):
     if ct in ('application/json', 'text/javascript'):
         return json.loads(content)
     elif ct in ('application/xml', 'text/xml'):
-        # technically, text/xml is ascii based but because many
-        # implementations get that wrong and utf-8 is a superset
-        # of utf-8 anyways, so there is not much harm in assuming
-        # utf-8 here
-        charset = options.get('charset', 'utf-8')
-        return get_etree().fromstring(content.decode(charset))
+        return get_etree().fromstring(content)
     elif ct != 'application/x-www-form-urlencoded':
         if strict:
             return content


### PR DESCRIPTION
The current version actually gives me an error: "UnicodeEncodeError: 'ascii' codec can't encode characters in position #-#: ordinal not in range(128)", since the XML I'm getting back has this information "<?xml version="1.0" encoding="UTF-8"?>"

Removing the extraneous decode fixes things for me. Is there a better way to work around the implementations that get the encoding wrong?

See: http://stackoverflow.com/questions/12349728/elementtree-and-unicode
