### PR TITLE
Fix python3 package location

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -10,7 +10,10 @@
 """
 import httplib2
 from functools import wraps
-from urlparse import urljoin
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 from flask import request, session, json, redirect, Response
 from werkzeug import url_decode, url_encode, url_quote, \
      parse_options_header, Headers


### PR DESCRIPTION
urlparse has been moved to be inside urllib.parse in python3. This commit should fix this dependency.
