### PR TITLE
Fix incorrect url_for route

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,7 +129,7 @@ request.  This function must be decorated as
 
     from flask import redirect
 
-    @app.route('/oauth-authorized')
+    @app.route('/oauth_authorized')
     @twitter.authorized_handler
     def oauth_authorized(resp):
         next_url = request.args.get('next') or url_for('index')


### PR DESCRIPTION
There is a small typo in the document where the route for oauth_authorized handler is oauth-authorized, which instead should be oauth_authorized since that's the url being called in the code.
