### PR TITLE
Remove duplicate return

### DIFF
--- a/example/google.py
+++ b/example/google.py
@@ -47,7 +47,6 @@ def index():
             # Unauthorized - bad token
             session.pop('access_token', None)
             return redirect(url_for('login'))
-        return res.read()
 
     return res.read()
 


### PR DESCRIPTION
Inner return is unnecessary since the default returns the same res.read()