### PR TITLE
Python 3 support

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -10,7 +10,10 @@
 """
 import httplib2
 from functools import wraps
-from urlparse import urljoin
+try:
+    from urllib.parse import urljoin
+except ImportError:
+     from urlparse import urljoin
 from flask import request, session, json, redirect, Response
 from werkzeug import url_decode, url_encode, url_quote, \
      parse_options_header, Headers


### PR DESCRIPTION
`urlparse` module was renamed to `urllib.parse` in python 3, with this commit this works on both python 2 and 3