### PR TITLE
except ModuleNotFoundError

### DIFF
--- a/flask_oauth.py
+++ b/flask_oauth.py
@@ -13,7 +13,7 @@ from functools import wraps
 # urlparse module has been renamed in Python 3.x
 try:
     from urlparse import urljoin
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     from urllib.parse import urljoin
 from flask import request, session, json, redirect, Response
 from werkzeug import url_decode, url_encode, url_quote, \


### PR DESCRIPTION
From version 3.6 ModuleNotFoundError will be thrown instead of ImportError