### PR TITLE
Mark this project as unmaintained

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-Flask-OAuth
-
-Implements basic OAuth support for Flask.  Currently it can only
-be used to hook up with external OAuth services.  It does not yet
-support implementing providers.
-
-Documentation: http://packages.python.org/Flask-OAuth/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Unmaintained
+
+Flask-OAuth is currently unmaintained. If you want to add OAuth support to
+your Flask website, we recommend using
+[Flask-Dance](https://github.com/singingwolfboy/flask-dance) instead,
+which is actively maintained.
+
+## Flask-OAuth
+
+Implements basic OAuth support for Flask.  It can only
+be used to hook up with external OAuth services.  It does not
+support implementing providers.
+
+Documentation: http://packages.python.org/Flask-OAuth/


### PR DESCRIPTION
Mark this project as unmaintained, and redirect developers to [Flask-Dance](https://github.com/singingwolfboy/flask-dance) instead. I discussed this change with @mitsuhiko before making this pull request.